### PR TITLE
Fix GitHub token env var

### DIFF
--- a/advanced_llm_apps/chat_with_X_tutorials/chat_with_github/README.md
+++ b/advanced_llm_apps/chat_with_X_tutorials/chat_with_github/README.md
@@ -28,8 +28,13 @@ pip install -r requirements.txt
 4. Get your GitHub Access Token
 
 - Create a [personal access token](https://docs.github.com/en/enterprise-server@3.6/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token) with the necessary permissions to access the desired GitHub repository.
+- Export the token as an environment variable so the app can authenticate:
 
-4. Run the Streamlit App
+```bash
+export GITHUB_TOKEN=your-github-token
+```
+
+5. Run the Streamlit App
 ```bash
 streamlit run chat_github.py
 ```

--- a/advanced_llm_apps/chat_with_X_tutorials/chat_with_github/chat_github_llama3.py
+++ b/advanced_llm_apps/chat_with_X_tutorials/chat_with_github/chat_github_llama3.py
@@ -5,7 +5,11 @@ from embedchain.loaders.github import GithubLoader
 import streamlit as st
 import os
 
-GITHUB_TOKEN = os.getenv("Your GitHub Token")
+# GitHub access token must be provided via the `GITHUB_TOKEN` environment
+# variable. Create a personal access token with appropriate permissions and
+# export it before running the app:
+#   export GITHUB_TOKEN=your-token
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 
 def get_loader():
     loader = GithubLoader(


### PR DESCRIPTION
## Summary
- update `chat_github_llama3.py` to use `os.getenv("GITHUB_TOKEN")`
- note the required `GITHUB_TOKEN` env variable in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508762e73483239eadc2717d084182