### PR TITLE
Fix typo in web scrapping AI agent prompts

### DIFF
--- a/starter_ai_agents/web_scrapping_ai_agent/ai_scrapper.py
+++ b/starter_ai_agents/web_scrapping_ai_agent/ai_scrapper.py
@@ -24,7 +24,7 @@ if openai_access_token:
     # Get the URL of the website to scrape
     url = st.text_input("Enter the URL of the website you want to scrape")
     # Get the user prompt
-    user_prompt = st.text_input("What you want the AI agent to scrae from the website?")
+    user_prompt = st.text_input("What do you want the AI agent to scrape from the website?")
     
     # Create a SmartScraperGraph object
     smart_scraper_graph = SmartScraperGraph(

--- a/starter_ai_agents/web_scrapping_ai_agent/local_ai_scrapper.py
+++ b/starter_ai_agents/web_scrapping_ai_agent/local_ai_scrapper.py
@@ -23,7 +23,7 @@ graph_config = {
 # Get the URL of the website to scrape
 url = st.text_input("Enter the URL of the website you want to scrape")
 # Get the user prompt
-user_prompt = st.text_input("What you want the AI agent to scrae from the website?")
+user_prompt = st.text_input("What do you want the AI agent to scrape from the website?")
 
 # Create a SmartScraperGraph object
 smart_scraper_graph = SmartScraperGraph(


### PR DESCRIPTION
## Summary
- fix text input question in `ai_scrapper.py` and `local_ai_scrapper.py`
- remove misspelling 'scrae'

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685087616a548323926d4a000aedf07a