### PR TITLE
Fix web scrapper README path

### DIFF
--- a/starter_ai_agents/web_scrapping_ai_agent/README.md
+++ b/starter_ai_agents/web_scrapping_ai_agent/README.md
@@ -12,7 +12,7 @@ This Streamlit app allows you to scrape a website using OpenAI API and the scrap
 
 ```bash
 git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
-cd awesome-llm-apps/advanced_tools_frameworks/web_scrapping_ai_agent
+cd awesome-llm-apps/starter_ai_agents/web_scrapping_ai_agent
 ```
 2. Install the required dependencies:
 


### PR DESCRIPTION
## Summary
- fix navigation path in README

## Testing
- `grep -n "starter_ai_agents" starter_ai_agents/web_scrapping_ai_agent/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68508764ea648323b3d32d655f75008f